### PR TITLE
Fixes #52 (More detailed docstrings in posterior.py and shape information)

### DIFF
--- a/popclass/posterior.py
+++ b/popclass/posterior.py
@@ -9,22 +9,23 @@ import numpy as np
 
 class InferenceData:
     """
-    ``popclass`` verion of an object containing the inference
-    data for classification.
+    ``popclass`` version of an object containing the inference
+    data for classification, including posterior samples and prior density.
 
-    Similar to ``popclass.Posterior``, but is intended to include prior infrmation
+    Similar to ``popclass.Posterior``, but is intended to include prior information
     to be passed to the classifier.
     """
 
     def __init__(self, posterior, prior_density):
         """
-        Initialize the InferenceData object
+        Initialize the InferenceData object.
 
         Args:
             posterior (popclass.Posterior):
-                A posterior object in popclass formatting convention
+                A posterior object in popclass formatting convention, containing posterior 
+                samples of the shape (number of samples, number of parameters)
             prior_density (array-like):
-
+                1D array representing the prior density with an expected shape of (number of samples,)
         """
         self.posterior = posterior
         self.prior_density = prior_density
@@ -33,7 +34,8 @@ class InferenceData:
 class Posterior:
     """
     ``popclass`` object containing the user's posterior information.
-    This can be either from data arrays or an allowable format.
+    This object can either be initialized from data arrays, or come from outside libraries in a 
+    compatible format. Acceptable formats from outside sources are listed below.
 
     **Supported Formats**:
 
@@ -47,11 +49,13 @@ class Posterior:
 
         Args:
             samples (array-like):
-                Posterior samples
+                Posterior samples with a shape of (number of samples, number of parameters). 
+                Rows correspond to individual samples drawn from the posterior distribution, 
+                and columns correspond to specific parameters.
             parameter_labels (list[str]):
-                Labels of the paramater labels corresponding to
-                posterior samples.
-
+                List of strings representing the labels of the parameters. 
+                There should be an equal number of labels to columns in samples representing 
+                individual parameters (i.e. the number of parameters).
         """
         testnan = np.isnan(samples)
         if True in testnan:
@@ -66,12 +70,12 @@ class Posterior:
 
         Args:
             parameter_list (list[str]):
-                List of parameters for generating marginal.
-                Should be a subset of ``Posterior.parameter_labels()``
+                List of parameters for generating a marginal distribution.
+                Should be a subset of ``Posterior.parameter_labels()``.
 
         Returns:
-            New instance of ``Posterior`` object containing samples
-            determined and ordered by `parameter_list`.
+            New instance of the ``Posterior`` object only containing 
+            samples determined and ordered by `parameter_list`. 
         """
 
         _1, id_arr_labels, id_arr_list = np.intersect1d(
@@ -86,39 +90,45 @@ class Posterior:
     @property
     def parameters(self):
         """
+        Defines an ordered list of parameters for the ``Posterior`` object.
+        
         Returns:
-            paramaters (list [str]):
-                Ordered list of parameters in ``Posterior`` object.
+            parameters (list [str]):
+                Ordered list of parameters in the ``Posterior`` object.           
         """
         return self.parameter_labels
 
     def to_inference_data(self, prior_density):
         """
-        Go from ``Posterior`` object to a new ``InferenceData`` object.
+        Go from the ``Posterior`` object to a new ``InferenceData`` object.
 
         Args:
-            posterior_object (popclass.Posterior)
-                Either a popclass ``Posterior`` or ``Posterior.marginal()``
-            prior_density (array-like)
-                Prior density corresponding to samples in posterior_object
+            posterior_object (popclass.Posterior):
+                Either a popclass ``Posterior`` or ``Posterior.marginal() `` object.
+            prior_density (array-like):
+                1D array representing the prior density with an expected shape of (number of samples,).
+                Prior density corresponds to samples in posterior_object, as the number of entries must 
+                match the number of rows in the posterior samples array.
 
         Returns:
-            An ``InferenceData`` object that contains all information needed
-            to pass to classifier
-        """
+            popclass.InferenceData:
+                An ``InferenceData`` object that contains all the information needed 
+                to pass to a classifier.         
+        """ 
         return InferenceData(posterior=self, prior_density=prior_density)
 
     @classmethod
     def from_arviz(cls, arviz_posterior_object):
         """
-        Utility to convert an ArViz posterior object directly to popclass posterior object
+        Utility to convert an ArViz posterior object directly to popclass posterior object.
 
         Args:
             arviz_posterior_object (arviz.InferenceData):
-                InferenceData from an ArViz run
+                InferenceData from an ArViz run.
 
         Returns:
-            ``popclass.Posterior`` object
+            popclass.Posterior:
+                A ``popclass.Posterior`` object generated from the ArViz posterior.        
         """
         labels = list(arviz_posterior_object.posterior.data_vars.keys())
         samples = list(arviz_posterior_object.posterior.to_dataarray().to_numpy())
@@ -127,17 +137,18 @@ class Posterior:
     @classmethod
     def from_pymultinest(cls, pymultinest_analyzer_object, parameter_labels):
         """
-        Utility to convert a PyMultiNest posterior to a popclass posterior
+        Utility to convert a PyMultiNest posterior to a popclass posterior object.
 
         Args:
             pymultinest_analyzer_object:
                 Analyzer object from PyMultiNest
-            parameter_labels:
-                ordered list of parameters. Should correspond to the order of
-                parameterss in ``pymultinest_analyzer_object``
+            parameter_labels (list[str]):
+                Ordered list of parameters. Should correspond to the order of
+                parameters in ``pymultinest_analyzer_object``.
 
         Returns:
-            ``popclass.Posterior`` object
+            popclass.Posterior:
+                A ``Posterior`` object with samples from the PyMultiNest analysis.        
         """
         samples = pymultinest_analyzer_object.get_equal_weighted_posterior()
 

--- a/popclass/posterior.py
+++ b/popclass/posterior.py
@@ -22,7 +22,7 @@ class InferenceData:
 
         Args:
             posterior (popclass.Posterior):
-                A posterior object in popclass formatting convention, containing posterior 
+                A posterior object in popclass formatting convention, containing posterior
                 samples of the shape (number of samples, number of parameters)
             prior_density (array-like):
                 1D array representing the prior density with an expected shape of (number of samples,)
@@ -34,7 +34,7 @@ class InferenceData:
 class Posterior:
     """
     ``popclass`` object containing the user's posterior information.
-    This object can either be initialized from data arrays, or come from outside libraries in a 
+    This object can either be initialized from data arrays, or come from outside libraries in a
     compatible format. Acceptable formats from outside sources are listed below.
 
     **Supported Formats**:
@@ -49,12 +49,12 @@ class Posterior:
 
         Args:
             samples (array-like):
-                Posterior samples with a shape of (number of samples, number of parameters). 
-                Rows correspond to individual samples drawn from the posterior distribution, 
+                Posterior samples with a shape of (number of samples, number of parameters).
+                Rows correspond to individual samples drawn from the posterior distribution,
                 and columns correspond to specific parameters.
             parameter_labels (list[str]):
-                List of strings representing the labels of the parameters. 
-                There should be an equal number of labels to columns in samples representing 
+                List of strings representing the labels of the parameters.
+                There should be an equal number of labels to columns in samples representing
                 individual parameters (i.e. the number of parameters).
         """
         testnan = np.isnan(samples)
@@ -74,8 +74,8 @@ class Posterior:
                 Should be a subset of ``Posterior.parameter_labels()``.
 
         Returns:
-            New instance of the ``Posterior`` object only containing 
-            samples determined and ordered by `parameter_list`. 
+            New instance of the ``Posterior`` object only containing
+            samples determined and ordered by `parameter_list`.
         """
 
         _1, id_arr_labels, id_arr_list = np.intersect1d(
@@ -91,10 +91,10 @@ class Posterior:
     def parameters(self):
         """
         Defines an ordered list of parameters for the ``Posterior`` object.
-        
+
         Returns:
             parameters (list [str]):
-                Ordered list of parameters in the ``Posterior`` object.           
+                Ordered list of parameters in the ``Posterior`` object.
         """
         return self.parameter_labels
 
@@ -107,14 +107,14 @@ class Posterior:
                 Either a popclass ``Posterior`` or ``Posterior.marginal() `` object.
             prior_density (array-like):
                 1D array representing the prior density with an expected shape of (number of samples,).
-                Prior density corresponds to samples in posterior_object, as the number of entries must 
+                Prior density corresponds to samples in posterior_object, as the number of entries must
                 match the number of rows in the posterior samples array.
 
         Returns:
             popclass.InferenceData:
-                An ``InferenceData`` object that contains all the information needed 
-                to pass to a classifier.         
-        """ 
+                An ``InferenceData`` object that contains all the information needed
+                to pass to a classifier.
+        """
         return InferenceData(posterior=self, prior_density=prior_density)
 
     @classmethod
@@ -128,7 +128,7 @@ class Posterior:
 
         Returns:
             popclass.Posterior:
-                A ``popclass.Posterior`` object generated from the ArViz posterior.        
+                A ``popclass.Posterior`` object generated from the ArViz posterior.
         """
         labels = list(arviz_posterior_object.posterior.data_vars.keys())
         samples = list(arviz_posterior_object.posterior.to_dataarray().to_numpy())
@@ -148,7 +148,7 @@ class Posterior:
 
         Returns:
             popclass.Posterior:
-                A ``Posterior`` object with samples from the PyMultiNest analysis.        
+                A ``Posterior`` object with samples from the PyMultiNest analysis.
         """
         samples = pymultinest_analyzer_object.get_equal_weighted_posterior()
 


### PR DESCRIPTION
Fixes #52  

## Description of the Change
I added a bit more detail to the docstrings in the popclass/posterior.py document, and added shape information for the samples, posterior, and prior_density variables.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] Added package dependency
- [ ] Added data
- [x] Documentation change
- [ ] code change

### **Additional context**
I did not address the expansion of the code to throw errors if shapes are wrong/reversed. Questions on that process will be addressed in an email and I can likely revisit this issue tomorrow if you would like me to proceed.