### PR TITLE
Addition of value errors and testing for posterior.py (Issue #61)

### DIFF
--- a/popclass/posterior.py
+++ b/popclass/posterior.py
@@ -58,7 +58,7 @@ class Posterior:
                 individual parameters (i.e. the number of parameters).
 
         Raises:
-            ValueError: if the number of samples is less than the number of parameters.
+            ValueError: if the number of parameters is not less than the number of samples.
         """
         testnan = np.isnan(samples)
         if True in testnan:
@@ -84,7 +84,8 @@ class Posterior:
             New instance of the ``Posterior`` object only containing
             samples determined and ordered by `parameter_list`.
 
-        Raises: ValueError if the number of samples is less than the number of parameters.
+        Raises: 
+            ValueError: if the number of parameters is not less than the number of samples.
         """
 
         _1, id_arr_labels, id_arr_list = np.intersect1d(
@@ -96,7 +97,7 @@ class Posterior:
 
         # Shape check
         if marginal.samples.shape[0] <= marginal.samples.shape[1]:
-            raise ValueError('Number of samples in marginal must be greater than number of parameters!')
+            raise ValueError('Number of samples in marginal array must be greater than number of parameters!')
 
         return marginal
 
@@ -142,6 +143,9 @@ class Posterior:
         Returns:
             popclass.Posterior:
                 A ``popclass.Posterior`` object generated from the ArViz posterior.
+
+        Raises: 
+            ValueError: if the number of parameters is not less than the number of samples. 
         """
         labels = list(arviz_posterior_object.posterior.data_vars.keys())
         samples = list(arviz_posterior_object.posterior.to_dataarray().to_numpy())
@@ -169,8 +173,15 @@ class Posterior:
         Returns:
             popclass.Posterior:
                 A ``Posterior`` object with samples from the PyMultiNest analysis.
+
+        Raises:
+            ValueError: if the number of parameters is not less than the number of samples.
         """
         samples = pymultinest_analyzer_object.get_equal_weighted_posterior()
+
+        # Shape check
+        if samples.shape[0] <= samples.shape[1]:
+            raise ValueError('Number of samples in pymultinest array must be greater than number of parameters!')
 
         return Posterior(samples, parameter_labels)
 

--- a/popclass/posterior.py
+++ b/popclass/posterior.py
@@ -56,10 +56,17 @@ class Posterior:
                 List of strings representing the labels of the parameters.
                 There should be an equal number of labels to columns in samples representing
                 individual parameters (i.e. the number of parameters).
+
+        Raises:
+            ValueError: if the number of samples is less than the number of parameters.
         """
         testnan = np.isnan(samples)
         if True in testnan:
             raise ValueError("Posterior samples cannot be NaN")
+
+        # Check that number of samples > number of parameters
+        if samples.shape[0] <= samples.shape[1]:
+            raise ValueError('Number of samples must be greater than number of parameters!')
 
         self.parameter_labels = parameter_labels
         self.samples = samples
@@ -76,6 +83,8 @@ class Posterior:
         Returns:
             New instance of the ``Posterior`` object only containing
             samples determined and ordered by `parameter_list`.
+
+        Raises: ValueError if the number of samples is less than the number of parameters.
         """
 
         _1, id_arr_labels, id_arr_list = np.intersect1d(
@@ -84,6 +93,10 @@ class Posterior:
         marginal = copy.deepcopy(self)
         marginal.parameter_labels = list([parameter_list[i] for i in id_arr_list])
         marginal.samples = self.samples[:, id_arr_labels]
+
+        # Shape check
+        if marginal.samples.shape[0] <= marginal.samples.shape[1]:
+            raise ValueError('Number of samples in marginal must be greater than number of parameters!')
 
         return marginal
 
@@ -132,6 +145,7 @@ class Posterior:
         """
         labels = list(arviz_posterior_object.posterior.data_vars.keys())
         samples = list(arviz_posterior_object.posterior.to_dataarray().to_numpy())
+        
         return cls(np.array(samples).swapaxes(0, 1), labels)
 
     @classmethod

--- a/popclass/posterior.py
+++ b/popclass/posterior.py
@@ -66,7 +66,9 @@ class Posterior:
 
         # Check that number of samples > number of parameters
         if samples.shape[0] <= samples.shape[1]:
-            raise ValueError('Number of samples must be greater than number of parameters!')
+            raise ValueError(
+                "Number of samples must be greater than number of parameters!"
+            )
 
         self.parameter_labels = parameter_labels
         self.samples = samples
@@ -84,7 +86,7 @@ class Posterior:
             New instance of the ``Posterior`` object only containing
             samples determined and ordered by `parameter_list`.
 
-        Raises: 
+        Raises:
             ValueError: if the number of parameters is not less than the number of samples.
         """
 
@@ -97,7 +99,9 @@ class Posterior:
 
         # Shape check
         if marginal.samples.shape[0] <= marginal.samples.shape[1]:
-            raise ValueError('Number of samples in marginal array must be greater than number of parameters!')
+            raise ValueError(
+                "Number of samples in marginal array must be greater than number of parameters!"
+            )
 
         return marginal
 
@@ -144,8 +148,8 @@ class Posterior:
             popclass.Posterior:
                 A ``popclass.Posterior`` object generated from the ArViz posterior.
 
-        Raises: 
-            ValueError: if the number of parameters is not less than the number of samples. 
+        Raises:
+            ValueError: if the number of parameters is not less than the number of samples.
         """
         labels = list(arviz_posterior_object.posterior.data_vars.keys())
         samples = list(arviz_posterior_object.posterior.to_dataarray().to_numpy())
@@ -154,8 +158,10 @@ class Posterior:
 
         # Shape check
         if samples_array.shape[0] <= samples_array.shape[1]:
-            raise ValueError('Number of samples in arviz array must be greater than number of parameters!')
-        
+            raise ValueError(
+                "Number of samples in arviz array must be greater than number of parameters!"
+            )
+
         return cls(samples_array, labels)
 
     @classmethod
@@ -181,7 +187,9 @@ class Posterior:
 
         # Shape check
         if samples.shape[0] <= samples.shape[1]:
-            raise ValueError('Number of samples in pymultinest array must be greater than number of parameters!')
+            raise ValueError(
+                "Number of samples in pymultinest array must be greater than number of parameters!"
+            )
 
         return Posterior(samples, parameter_labels)
 

--- a/popclass/posterior.py
+++ b/popclass/posterior.py
@@ -145,8 +145,14 @@ class Posterior:
         """
         labels = list(arviz_posterior_object.posterior.data_vars.keys())
         samples = list(arviz_posterior_object.posterior.to_dataarray().to_numpy())
+
+        samples_array = np.array(samples).swapaxes(0, 1)
+
+        # Shape check
+        if samples_array.shape[0] <= samples_array.shape[1]:
+            raise ValueError('Number of samples in arviz array must be greater than number of parameters!')
         
-        return cls(np.array(samples).swapaxes(0, 1), labels)
+        return cls(samples_array, labels)
 
     @classmethod
     def from_pymultinest(cls, pymultinest_analyzer_object, parameter_labels):

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -74,7 +74,13 @@ def test_shape_check_init():
     """
     Test that a ValueError is raised if the initial array shape does not match the expected. 
     """
-    
+    # Case where samples = params
+    with pytest.raises(ValueError, match = 'Number of samples must be greater than number of parameters!'):
+        test_samples = np.random.rand(3, 3)
+        test_params = ["A", "B", "C"]
+        post = Posterior(samples=test_samples, parameter_labels=test_params)
+        
+    # Case where samples < params
     with pytest.raises(ValueError, match = 'Number of samples must be greater than number of parameters!'):
         test_samples = np.random.rand(2, 3)
         test_params = ["A", "B", "C"]
@@ -125,7 +131,9 @@ def test_convert_arviz():
     assert np.allclose(test_samples, popclass_from_az_post.samples)
 
 def test_shape_check_from_arviz():
-    
+    """
+    Test that a ValueError is raised if the arviz array shape does not match the expected.
+    """
     # Case where samples = params
     with pytest.raises(ValueError, 
                         match = 'Number of samples in arviz array must be greater than number of parameters!'):
@@ -167,6 +175,12 @@ def test_convert_pymultinest():
 
     assert np.array_equal(test_samples, popclass_post.samples)
     assert np.array_equal(test_params, popclass_post.parameter_labels)
+
+#def test_shape_check_from_pymultinest():
+#    """
+#    Test that a ValueError is raised if the pymultinest array shape does not match the expected.
+#    """
+    
 
 
 def test_to_InferenceData():

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -70,21 +70,27 @@ def test_nan_in_samples_exception():
         test_params = ["A", "B", "C"]
         post = Posterior(samples=test_samples, parameter_labels=test_params)
 
+
 def test_shape_check_init():
     """
-    Test that a ValueError is raised if the initial array shape does not match the expected. 
+    Test that a ValueError is raised if the initial array shape does not match the expected.
     """
     # Case where samples = params
-    with pytest.raises(ValueError, match = 'Number of samples must be greater than number of parameters!'):
+    with pytest.raises(
+        ValueError, match="Number of samples must be greater than number of parameters!"
+    ):
         test_samples = np.random.rand(3, 3)
         test_params = ["A", "B", "C"]
         post = Posterior(samples=test_samples, parameter_labels=test_params)
-        
+
     # Case where samples < params
-    with pytest.raises(ValueError, match = 'Number of samples must be greater than number of parameters!'):
+    with pytest.raises(
+        ValueError, match="Number of samples must be greater than number of parameters!"
+    ):
         test_samples = np.random.rand(2, 3)
         test_params = ["A", "B", "C"]
         post = Posterior(samples=test_samples, parameter_labels=test_params)
+
 
 def test_shape_check_marginal():
     """
@@ -95,22 +101,31 @@ def test_shape_check_marginal():
     post = Posterior(samples=test_samples, parameter_labels=test_params)
 
     # Case where samples = params
-    with pytest.raises(ValueError, 
-                       match = 'Number of samples in marginal must be greater than number of parameters!'):
-        marginal_invalid = post.marginal(parameter_list = ["A", "B"])
+    with pytest.raises(
+        ValueError,
+        match="Number of samples in marginal must be greater than number of parameters!",
+    ):
+        marginal_invalid = post.marginal(parameter_list=["A", "B"])
         marginal_invalid.samples = np.random.rand(2, 2)
-        
+
         if marginal_invalid.samples.shape[0] <= marginal_invalid.samples.shape[1]:
-            raise ValueError('Number of samples in marginal must be greater than number of parameters!')
+            raise ValueError(
+                "Number of samples in marginal must be greater than number of parameters!"
+            )
 
     # Case where samples < params
-    with pytest.raises(ValueError, 
-                       match = 'Number of samples in marginal must be greater than number of parameters!'):
-        marginal_invalid = post.marginal(parameter_list = ["A", "B"])
+    with pytest.raises(
+        ValueError,
+        match="Number of samples in marginal must be greater than number of parameters!",
+    ):
+        marginal_invalid = post.marginal(parameter_list=["A", "B"])
         marginal_invalid.samples = np.random.rand(2, 3)
-        
+
         if marginal_invalid.samples.shape[0] <= marginal_invalid.samples.shape[1]:
-            raise ValueError('Number of samples in marginal must be greater than number of parameters!')
+            raise ValueError(
+                "Number of samples in marginal must be greater than number of parameters!"
+            )
+
 
 def test_convert_arviz():
     """
@@ -130,39 +145,45 @@ def test_convert_arviz():
 
     assert np.allclose(test_samples, popclass_from_az_post.samples)
 
+
 def test_shape_check_from_arviz():
     """
     Test that a ValueError is raised if the arviz array shape does not match the expected.
     """
     # Case where samples = params
-    with pytest.raises(ValueError, 
-                        match = 'Number of samples in arviz array must be greater than number of parameters!'):
+    with pytest.raises(
+        ValueError,
+        match="Number of samples in arviz array must be greater than number of parameters!",
+    ):
         test_samples = np.random.rand(3, 3)
         test_params = ["A", "B", "C"]
-        
+
         post = {
             test_params[0]: test_samples[0, :],
             test_params[1]: test_samples[1, :],
             test_params[2]: test_samples[2, :],
         }
-        
+
         az_post = az.convert_to_inference_data(post)
         popclass_from_az_post = Posterior.from_arviz(az_post)
-        
+
     # Case where samples < params
-    with pytest.raises(ValueError, 
-                        match = 'Number of samples in arviz array must be greater than number of parameters!'):
+    with pytest.raises(
+        ValueError,
+        match="Number of samples in arviz array must be greater than number of parameters!",
+    ):
         test_samples = np.random.rand(2, 3)
         test_params = ["A", "B", "C"]
-        
+
         post = {
             test_params[0]: test_samples[0, :],
             test_params[1]: test_samples[1, :],
-            test_params[2]: test_samples[1, :],   #read again for assignment
+            test_params[2]: test_samples[1, :],  # read again for assignment
         }
-        
+
         az_post = az.convert_to_inference_data(post)
         popclass_from_az_post = Posterior.from_arviz(az_post)
+
 
 def test_convert_pymultinest():
     """
@@ -176,30 +197,38 @@ def test_convert_pymultinest():
     assert np.array_equal(test_samples, popclass_post.samples)
     assert np.array_equal(test_params, popclass_post.parameter_labels)
 
+
 def test_shape_check_from_pymultinest():
     """
     Test that a ValueError is raised if the pymultinest array shape does not match the expected.
     """
+
     # Case where samples = params
     class EqualAnalyzer:
         def get_equal_weighted_posterior(self):
             return np.random.rand(3, 3)
-            
-    with pytest.raises(ValueError, 
-                       match = 'Number of samples in pymultinest array must be greater than number of parameters!'):
+
+    with pytest.raises(
+        ValueError,
+        match="Number of samples in pymultinest array must be greater than number of parameters!",
+    ):
         test_params = ["A", "B", "C"]
         analyzer = EqualAnalyzer()
         Posterior.from_pymultinest(analyzer, test_params)
+
     # Case where samples < params
     class LesserAnalyzer:
         def get_equal_weighted_posterior(self):
             return np.random.rand(2, 3)
-            
-    with pytest.raises(ValueError, 
-                       match = 'Number of samples in pymultinest array must be greater than number of parameters!'):
+
+    with pytest.raises(
+        ValueError,
+        match="Number of samples in pymultinest array must be greater than number of parameters!",
+    ):
         test_params = ["A", "B", "C"]
         analyzer = LesserAnalyzer()
         Posterior.from_pymultinest(analyzer, test_params)
+
 
 def test_to_InferenceData():
     """

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -61,7 +61,7 @@ def test_marginal():
 
 def test_nan_in_samples_exception():
     """
-    Test that there is a check for NaNs in posterior samples when Posterior is constructed
+    Test that there is a check for NaNs in posterior samples when Posterior is constructed.
     """
 
     with pytest.raises(ValueError):
@@ -70,6 +70,41 @@ def test_nan_in_samples_exception():
         test_params = ["A", "B", "C"]
         post = Posterior(samples=test_samples, parameter_labels=test_params)
 
+def test_shape_check_init():
+    """
+    Test that a ValueError is raised if the initial array shape does not match the expected. 
+    """
+    
+    with pytest.raises(ValueError, match = 'Number of samples must be greater than number of parameters!'):
+        test_samples = np.random.rand(2, 3)
+        test_params = ["A", "B", "C"]
+        post = Posterior(samples=test_samples, parameter_labels=test_params)
+
+def test_shape_check_marginal():
+    """
+    Test that a ValueError is raised if the array shape of marginal distribution does not match the expected.
+    """
+    test_samples = np.random.rand(1000, 2)
+    test_params = ["A", "B"]
+    post = Posterior(samples=test_samples, parameter_labels=test_params)
+
+    # Case where samples = params
+    with pytest.raises(ValueError, 
+                       match = 'Number of samples in marginal must be greater than number of parameters!'):
+        marginal_invalid = post.marginal(parameter_list = ["A", "B"])
+        marginal_invalid.samples = np.random.rand(2, 2)
+        
+        if marginal_invalid.samples.shape[0] <= marginal_invalid.samples.shape[1]:
+            raise ValueError('Number of samples in marginal must be greater than number of parameters!')
+
+    # Case where samples < params
+    with pytest.raises(ValueError, 
+                       match = 'Number of samples in marginal must be greater than number of parameters!'):
+        marginal_invalid = post.marginal(parameter_list = ["A", "B"])
+        marginal_invalid.samples = np.random.rand(2, 3)
+        
+        if marginal_invalid.samples.shape[0] <= marginal_invalid.samples.shape[1]:
+            raise ValueError('Number of samples in marginal must be greater than number of parameters!')
 
 def test_convert_arviz():
     """

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -176,12 +176,30 @@ def test_convert_pymultinest():
     assert np.array_equal(test_samples, popclass_post.samples)
     assert np.array_equal(test_params, popclass_post.parameter_labels)
 
-#def test_shape_check_from_pymultinest():
-#    """
-#    Test that a ValueError is raised if the pymultinest array shape does not match the expected.
-#    """
-    
-
+def test_shape_check_from_pymultinest():
+    """
+    Test that a ValueError is raised if the pymultinest array shape does not match the expected.
+    """
+    # Case where samples = params
+    class EqualAnalyzer:
+        def get_equal_weighted_posterior(self):
+            return np.random.rand(3, 3)
+            
+    with pytest.raises(ValueError, 
+                       match = 'Number of samples in pymultinest array must be greater than number of parameters!'):
+        test_params = ["A", "B", "C"]
+        analyzer = EqualAnalyzer()
+        Posterior.from_pymultinest(analyzer, test_params)
+    # Case where samples < params
+    class LesserAnalyzer:
+        def get_equal_weighted_posterior(self):
+            return np.random.rand(2, 3)
+            
+    with pytest.raises(ValueError, 
+                       match = 'Number of samples in pymultinest array must be greater than number of parameters!'):
+        test_params = ["A", "B", "C"]
+        analyzer = LesserAnalyzer()
+        Posterior.from_pymultinest(analyzer, test_params)
 
 def test_to_InferenceData():
     """

--- a/tests/test_posterior.py
+++ b/tests/test_posterior.py
@@ -124,6 +124,37 @@ def test_convert_arviz():
 
     assert np.allclose(test_samples, popclass_from_az_post.samples)
 
+def test_shape_check_from_arviz():
+    
+    # Case where samples = params
+    with pytest.raises(ValueError, 
+                        match = 'Number of samples in arviz array must be greater than number of parameters!'):
+        test_samples = np.random.rand(3, 3)
+        test_params = ["A", "B", "C"]
+        
+        post = {
+            test_params[0]: test_samples[0, :],
+            test_params[1]: test_samples[1, :],
+            test_params[2]: test_samples[2, :],
+        }
+        
+        az_post = az.convert_to_inference_data(post)
+        popclass_from_az_post = Posterior.from_arviz(az_post)
+        
+    # Case where samples < params
+    with pytest.raises(ValueError, 
+                        match = 'Number of samples in arviz array must be greater than number of parameters!'):
+        test_samples = np.random.rand(2, 3)
+        test_params = ["A", "B", "C"]
+        
+        post = {
+            test_params[0]: test_samples[0, :],
+            test_params[1]: test_samples[1, :],
+            test_params[2]: test_samples[1, :],   #read again for assignment
+        }
+        
+        az_post = az.convert_to_inference_data(post)
+        popclass_from_az_post = Posterior.from_arviz(az_post)
 
 def test_convert_pymultinest():
     """


### PR DESCRIPTION
Fixes #61 

## Description of the Change
Added a check for the correct shape of arrays each time a samples array is passed into a function. Namely, in popclass/posterior.py, the functions posterior.__init__, posterior.marginal, posterior.from_arviz, and posterior.from_pymultinest all have unique value errors that get raised if the array shapes do not appear as expected. I also added testing for each of these individual value errors in tests/test_posterior.py. I also updated the docstrings on the functions to add a description of the value errors.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] Added package dependency
- [ ] Added data
- [x] Documentation change
- [x] code change

### **Additional context**
